### PR TITLE
Fix Image Rendering and Optimize Contextual Images for Speed

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -147,7 +147,7 @@ ul {
     gap: 1.2rem;
     padding: 6rem 1.25rem 2rem;
     background-image: linear-gradient(90deg, rgba(26, 26, 26, 0.72), rgba(26, 26, 26, 0.18)),
-        url('https://placehold.co/1600x1100/C8832A/1A1A1A?text=CrazyCook');
+        url('https://images.unsplash.com/photo-1555939594-58d7cb561ad1?auto=format&fit=crop&w=1200&h=800&q=60');
     background-size: cover;
     background-position: center;
     color: white;
@@ -1234,15 +1234,9 @@ ul {
     gap: 1rem;
 }
 .rating-badge {
-<<<<<<< HEAD
-    background: rgba(255,255,255,0.06);
-    color: var(--dark);
-    border: 1px solid rgba(255,255,255,0.06);
-=======
     background: rgba(0,0,0,0.05);
     color: var(--dark);
     border: 1px solid rgba(0,0,0,0.08);
->>>>>>> 4021493e328229e9a7f806ec8546660f70adcb7c
     padding: 0.45rem 0.7rem;
     border-radius: 999px;
     font-weight: 700;

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
                     <figure class="gallery-item">
                         <div class="media-wrap">
                             <span class="img-skeleton" aria-hidden="true"></span>
-                            <img class="skeleton-img" onload="imageLoaded(this)" onerror="imageFailed(this)" src="https://images.unsplash.com/photo-1556910103-1c02745aae4d?auto=format&fit=crop&w=800&h=1000&q=80" alt="Le chef de CrazyCook en pleine préparation culinaire au feu de bois">
+                            <img class="skeleton-img" onload="imageLoaded(this)" onerror="imageFailed(this)" src="https://images.unsplash.com/photo-1556910103-1c02745aae4d?auto=format&fit=crop&w=800&h=1000&q=60" loading="lazy" alt="Le chef de CrazyCook en pleine préparation culinaire au feu de bois">
                         </div>
                         <figcaption>L'art du feu de bois</figcaption>
                     </figure>
@@ -245,28 +245,28 @@
                 <figure class="gallery-item large reveal">
                     <div class="media-wrap">
                         <span class="img-skeleton" aria-hidden="true"></span>
-                        <img class="skeleton-img" onload="imageLoaded(this)" onerror="imageFailed(this)" src="https://images.unsplash.com/photo-1514933651103-005eec06c04b?auto=format&fit=crop&w=1200&h=900&q=80" alt="Ambiance du restaurant">
+                        <img class="skeleton-img" onload="imageLoaded(this)" onerror="imageFailed(this)" src="https://images.unsplash.com/photo-1514933651103-005eec06c04b?auto=format&fit=crop&w=1200&h=900&q=60" loading="lazy" alt="Ambiance du restaurant">
                     </div>
                     <figcaption>Ambiance de soirée</figcaption>
                 </figure>
                 <figure class="gallery-item reveal">
                     <div class="media-wrap">
                         <span class="img-skeleton" aria-hidden="true"></span>
-                        <img class="skeleton-img" onload="imageLoaded(this)" onerror="imageFailed(this)" src="https://images.unsplash.com/photo-1604329760661-e71dc83f8f26?auto=format&fit=crop&w=700&h=700&q=80" alt="Assiette préparée">
+                        <img class="skeleton-img" onload="imageLoaded(this)" onerror="imageFailed(this)" src="https://images.unsplash.com/photo-1604329760661-e71dc83f8f26?auto=format&fit=crop&w=700&h=700&q=60" loading="lazy" alt="Assiette préparée">
                     </div>
                     <figcaption>Assiette du chef</figcaption>
                 </figure>
                 <figure class="gallery-item tall reveal">
                     <div class="media-wrap">
                         <span class="img-skeleton" aria-hidden="true"></span>
-                        <img class="skeleton-img" onload="imageLoaded(this)" onerror="imageFailed(this)" src="https://images.unsplash.com/photo-1577219491135-ce391730fb2c?auto=format&fit=crop&w=700&h=1000&q=80" alt="Cuisine en action">
+                        <img class="skeleton-img" onload="imageLoaded(this)" onerror="imageFailed(this)" src="https://images.unsplash.com/photo-1577219491135-ce391730fb2c?auto=format&fit=crop&w=700&h=1000&q=60" loading="lazy" alt="Cuisine en action">
                     </div>
                     <figcaption>Service en cuisine</figcaption>
                 </figure>
                 <figure class="gallery-item reveal">
                     <div class="media-wrap">
                         <span class="img-skeleton" aria-hidden="true"></span>
-                        <img class="skeleton-img" onload="imageLoaded(this)" onerror="imageFailed(this)" src="https://images.unsplash.com/photo-1559339352-11d035aa65de?auto=format&fit=crop&w=700&h=700&q=80" alt="Service en salle">
+                        <img class="skeleton-img" onload="imageLoaded(this)" onerror="imageFailed(this)" src="https://images.unsplash.com/photo-1559339352-11d035aa65de?auto=format&fit=crop&w=700&h=700&q=60" loading="lazy" alt="Service en salle">
                     </div>
                     <figcaption>Maison de saison</figcaption>
                 </figure>

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "failed",
+  "failedTests": []
+}


### PR DESCRIPTION
This PR resolves a critical CSS rendering bug caused by git merge conflict markers in `assets/css/style.css`. It also replaces placeholder images with high-quality, context-appropriate restaurant and cooking photos from Unsplash, and optimizes performance with lazy loading (`loading="lazy"`) and optimized compression params (`q=60`) for faster loading times.

---
*PR created automatically by Jules for task [7148313872435893623](https://jules.google.com/task/7148313872435893623) started by @sudomarc*