### PR TITLE
🎨 Palette: Menu & Checkout Drawer Accessibility Enhancements

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -188,13 +188,13 @@ document.addEventListener('DOMContentLoaded', () => {
                                     <strong>${item.name}</strong>
                                     <p>${formatPrice(item.price)} / unité</p>
                                 </div>
-                                <button type="button" class="cart-remove" data-remove="${item.name}">Supprimer</button>
+                                <button type="button" class="cart-remove" data-remove="${item.name}" aria-label="Supprimer ${item.name} du panier">Supprimer</button>
                             </div>
                             <div class="cart-item-card__meta">
                                 <div class="cart-stepper">
-                                    <button type="button" data-change="-" data-name="${item.name}">−</button>
-                                    <span>${item.quantity}</span>
-                                    <button type="button" data-change="+" data-name="${item.name}">+</button>
+                                    <button type="button" data-change="-" data-name="${item.name}" aria-label="Diminuer la quantité de ${item.name}">−</button>
+                                    <span aria-live="polite" aria-label="Quantité de ${item.name} : ${item.quantity}">${item.quantity}</span>
+                                    <button type="button" data-change="+" data-name="${item.name}" aria-label="Augmenter la quantité de ${item.name}">+</button>
                                 </div>
                                 <strong>${formatPrice(item.quantity * item.price)}</strong>
                             </div>
@@ -214,19 +214,19 @@ document.addEventListener('DOMContentLoaded', () => {
                     <h4 style="margin-bottom: 1rem; font-family: 'Cormorant Garamond', serif; font-size: 1.3rem; color: var(--burnt-earth);">Informations de livraison</h4>
                     <form class="cart-form" id="delivery-form">
                         <label>
-                            Nom complet
+                            <span>Nom complet <span class="required" aria-hidden="true" style="color: red;">*</span></span>
                             <input type="text" name="name" value="${deliveryInfo.name}" placeholder="Ex: Mamadou Diallo" required>
                         </label>
                         <label>
-                            Numéro de téléphone
+                            <span>Numéro de téléphone <span class="required" aria-hidden="true" style="color: red;">*</span></span>
                             <input type="tel" name="phone" value="${deliveryInfo.phone}" placeholder="Ex: +224 628 06 94 79" required>
                         </label>
                         <label>
-                            Adresse de livraison (ou lien Google Maps)
+                            <span>Adresse de livraison (ou lien Google Maps) <span class="required" aria-hidden="true" style="color: red;">*</span></span>
                             <input type="text" name="address" value="${deliveryInfo.address}" placeholder="Ex: Kaloum, Conakry" required>
                         </label>
                         <label>
-                            Note spéciale pour le chef
+                            <span>Note spéciale pour le chef</span>
                             <textarea name="note" placeholder="Ex: Épices douces, sans oignons...">${deliveryInfo.note}</textarea>
                         </label>
                         <div class="cart-actions" style="margin-top: 1rem; display: flex; gap: 0.5rem;">
@@ -278,7 +278,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     <p style="font-size: 0.9rem; margin: 0.5rem 0 1rem;">Montant à payer : <strong>${formatPrice(getSubtotal() + 2000)}</strong></p>
                     <form class="cart-form" id="om-form">
                         <label>
-                            Numéro Orange Money
+                            <span>Numéro Orange Money <span class="required" aria-hidden="true" style="color: red;">*</span></span>
                             <input type="tel" name="omPhone" value="${deliveryInfo.phone}" placeholder="Ex: 628 06 94 79" required>
                         </label>
                     </form>

--- a/index.html
+++ b/index.html
@@ -219,7 +219,7 @@
                         <p class="dish-desc">Bouillon profond, graines torréfiées et herbes fraîches.</p>
                         <p class="dish-detail">Un premier geste réconfortant, à la fois rustique et raffiné.</p>
                         <div class="dish-actions">
-                            <button type="button" class="add-to-cart" data-name="Soupe de haricot noir" data-price="8000">Ajouter au panier</button>
+                            <button type="button" class="add-to-cart" data-name="Soupe de haricot noir" data-price="8000" aria-label="Ajouter la Soupe de haricot noir au panier">Ajouter au panier</button>
                         </div>
                     </article>
                     <article class="dish-card">
@@ -230,7 +230,7 @@
                         <p class="dish-desc">Feuilles rôties, agrumes, noix et sauce de miel épicé.</p>
                         <p class="dish-detail">Équilibre, fraîcheur, et une vraie présence de terre.</p>
                         <div class="dish-actions">
-                            <button type="button" class="add-to-cart" data-name="Salade de saison" data-price="9000">Ajouter au panier</button>
+                            <button type="button" class="add-to-cart" data-name="Salade de saison" data-price="9000" aria-label="Ajouter la Salade de saison au panier">Ajouter au panier</button>
                         </div>
                     </article>
                 </div>
@@ -246,7 +246,7 @@
                         <p class="dish-desc">Marinées au gingembre, servies avec du couscous grillé.</p>
                         <p class="dish-detail">Un plat de partage, pensé pour la table et le feu.</p>
                         <div class="dish-actions">
-                            <button type="button" class="add-to-cart" data-name="Brochettes de bœuf" data-price="16000">Ajouter au panier</button>
+                            <button type="button" class="add-to-cart" data-name="Brochettes de bœuf" data-price="16000" aria-label="Ajouter les Brochettes de bœuf au panier">Ajouter au panier</button>
                         </div>
                     </article>
                     <article class="dish-card">
@@ -258,7 +258,7 @@
                         <p class="dish-desc">Épices douces, purée de pois cassés et huile d’herbes.</p>
                         <p class="dish-detail">Le genre de plat qui ralentit le temps.</p>
                         <div class="dish-actions">
-                            <button type="button" class="add-to-cart" data-name="Filet de poisson fumé" data-price="18000">Ajouter au panier</button>
+                            <button type="button" class="add-to-cart" data-name="Filet de poisson fumé" data-price="18000" aria-label="Ajouter le Filet de poisson fumé au panier">Ajouter au panier</button>
                         </div>
                     </article>
                 </div>
@@ -273,7 +273,7 @@
                         <p class="dish-desc">Crème vanillée, fruits qui éclatent et caramel croustillant.</p>
                         <p class="dish-detail">Légère, lumineuse, et pourtant très marquée.</p>
                         <div class="dish-actions">
-                            <button type="button" class="add-to-cart" data-name="Pavlova à la mangue" data-price="10000">Ajouter au panier</button>
+                            <button type="button" class="add-to-cart" data-name="Pavlova à la mangue" data-price="10000" aria-label="Ajouter la Pavlova à la mangue au panier">Ajouter au panier</button>
                         </div>
                     </article>
                 </div>


### PR DESCRIPTION
## UX Improvement: Menu & Checkout Drawer Accessibility Enhancements

This pull request introduces micro-UX and accessibility (a11y) enhancements to standard buttons and form inputs across the codebase:

1. **Explicit ARIA Labels:**
   - Added descriptive `aria-label` attributes to the "Ajouter au panier" menu action buttons, so screen-readers announce the exact dish being added.
   - Added `aria-label` to the minus/plus quantity stepper controls as well as the "Supprimer" button inside the checkout cart.
   - Enhanced the quantity span with `aria-live="polite"` and standard labeling.

2. **Semantic Forms & CSS Grid Support:**
   - Wrapped form input labels' inner text within `<span>` tags. This ensures that browsers' CSS Grid layout treats the label text and inputs as intended, preventing layout breakages.
   - Added precise visual asterisk indicators (`*` in red) to all required fields, while making them invisible (`aria-hidden="true"`) to assistive technologies to prevent annoying and repetitive screen-reader announcements.

All tests have been run and verified successfully.

---
*PR created automatically by Jules for task [2437081939878057068](https://jules.google.com/task/2437081939878057068) started by @sudomarc*