### PR TITLE
🎨 Palette: Add focus-visible indicators in checkout cart drawer

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1874,9 +1874,24 @@ ul {
     border-radius: 4px;
 }
 
-#header-cart-toggle:focus-visible {
+#header-cart-toggle:focus-visible,
+#mobile-cart-toggle:focus-visible,
+.cart-icon-button:focus-visible {
     outline: 2px solid var(--ochre);
     outline-offset: 4px;
+    border-radius: 4px;
+}
+
+.payment-option:focus-visible {
+    outline: 2px solid var(--ochre);
+    outline-offset: 3px;
+    border-radius: 16px;
+}
+
+.cart-stepper button:focus-visible,
+.cart-remove:focus-visible {
+    outline: 2px solid var(--ochre);
+    outline-offset: 2px;
     border-radius: 4px;
 }
 


### PR DESCRIPTION
This PR introduces beautiful, high-contrast :focus-visible indicators for interactive cart components within the multi-step checkout drawer (including payment options, item removal, quantity steppers, and cart toggles). This significantly improves keyboard navigation accessibility and delivers a smooth checkout experience for all users.

---
*PR created automatically by Jules for task [11368771187262148942](https://jules.google.com/task/11368771187262148942) started by @sudomarc*