### PR TITLE
🎨 Palette: Add screen reader live region announcements for cart actions

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -51,6 +51,19 @@ html {
     outline: none;
 }
 
+/* Visually hidden utility class for screen reader live regions and announcements */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 [data-theme="dark"] .skip-link {
     background: #FF6600;
     color: #F8F1E5;

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -25,6 +25,17 @@ document.addEventListener('DOMContentLoaded', () => {
     const reorderSummary = document.getElementById('reorder-summary');
     const reorderButton = document.getElementById('reorder-button');
     const reorderDismiss = document.getElementById('reorder-dismiss');
+    const cartLiveStatus = document.getElementById('cart-live-status');
+
+    // Annonce vocale pour les lecteurs d'écran lors des modifications du panier
+    const announceCartAction = (message) => {
+        if (cartLiveStatus) {
+            cartLiveStatus.textContent = '';
+            setTimeout(() => {
+                cartLiveStatus.textContent = message;
+            }, 50);
+        }
+    };
 
     // Gestion de l'état simple (Panier & Étape de commande)
     let cart = [];
@@ -519,6 +530,7 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
             cart.push({ name, price, quantity: 1 });
         }
+        announceCartAction(`${name} ajouté au panier.`);
         bumpBadge();
         renderCart();
     };
@@ -528,12 +540,19 @@ document.addEventListener('DOMContentLoaded', () => {
         cart = cart
             .map((item) => item.name === name ? { ...item, quantity: item.quantity + delta } : item)
             .filter((item) => item.quantity > 0);
+        const currentItem = cart.find(item => item.name === name);
+        if (currentItem) {
+            announceCartAction(`Quantité de ${name} : ${currentItem.quantity}`);
+        } else {
+            announceCartAction(`${name} retiré du panier.`);
+        }
         renderCart();
     };
 
     // Supprimer un plat du panier
     const removeItem = (name) => {
         cart = cart.filter((item) => item.name !== name);
+        announceCartAction(`${name} retiré du panier.`);
         renderCart();
     };
 

--- a/index.html
+++ b/index.html
@@ -58,6 +58,8 @@
 <body>
     <!-- Éviter la navigation répétitive pour les lecteurs d'écran et la navigation clavier -->
     <a href="#main-content" class="skip-link">Passer au contenu principal</a>
+    <!-- Zone d'annonce d'accessibilité dynamique pour la lecture d'écran -->
+    <div id="cart-live-status" class="sr-only" aria-live="polite" aria-atomic="true"></div>
 
     <!-- Header / Navigation -->
     <header class="site-header">
@@ -194,7 +196,7 @@
             </div>
 
                 <!-- Bannière de recommandation de la dernière commande (injectée si donnée disponible) -->
-                <div id="reorder-banner" class="reorder-banner" role="region" aria-live="polite" hidden>
+                <div id="reorder-banner" class="reorder-banner" role="region" aria-label="Recommander votre dernière commande" aria-live="polite" hidden>
                     <div class="reorder-content">
                         <div class="reorder-text">
                             <strong>Recommander votre dernière commande</strong>


### PR DESCRIPTION
💡 What: Added a polite screen reader live region (#cart-live-status) that dynamically announces cart additions, removals, and quantity updates. Added an explicit aria-label to the #reorder-banner region.

🎯 Why: Sighted users receive visual feedback (+1 animation and button text changes), but screen reader users lacked real-time feedback when interacting with cart buttons.

♿ Accessibility: Implemented standard WCAG aria-live="polite" notifications and landmark labeling.

---
*PR created automatically by Jules for task [4732189233540515625](https://jules.google.com/task/4732189233540515625) started by @sudomarc*