### PR TITLE
🎨 Palette: Add focus-visible style to reorder banner buttons

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2011,7 +2011,9 @@ ul {
 }
 
 .add-to-cart:focus-visible,
-.button:focus-visible {
+.button:focus-visible,
+#reorder-button:focus-visible,
+#reorder-dismiss:focus-visible {
     outline: 2px solid var(--ochre);
     outline-offset: 3px;
 }


### PR DESCRIPTION
Adds explicit `:focus-visible` styling for `#reorder-button` and `#reorder-dismiss` in `assets/css/style.css` to ensure keyboard navigation users receive clear visual feedback matching the rest of the application's design system focus indicators.

---
*PR created automatically by Jules for task [13447238306028889084](https://jules.google.com/task/13447238306028889084) started by @sudomarc*