### PR TITLE
🎨 Palette: Add accessible floating "Back to Top" button

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2105,3 +2105,50 @@ ul {
 [data-theme="dark"] .cart-ref-text {
     color: #D8CDB8;
 }
+
+/* Floating Back-to-Top Button */
+.back-to-top {
+    position: fixed;
+    bottom: 2rem;
+    right: 2rem;
+    z-index: 99;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: var(--burnt-earth);
+    color: var(--cream);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.2);
+    transition: transform 0.25s var(--ease-premium), background-color 0.25s ease, opacity 0.25s ease;
+}
+
+.back-to-top:hover {
+    background: var(--ochre);
+    transform: translateY(-3px);
+}
+
+.back-to-top:focus-visible {
+    outline: 2px solid var(--ochre);
+    outline-offset: 3px;
+}
+
+[data-theme="dark"] .back-to-top {
+    background: var(--ochre);
+    color: var(--dark);
+}
+
+[data-theme="dark"] .back-to-top:hover {
+    background: var(--burnt-earth);
+    color: var(--cream);
+}
+
+@media (max-width: 768px) {
+    .back-to-top {
+        bottom: 5rem;
+        right: 1.25rem;
+    }
+}

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -26,6 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const reorderButton = document.getElementById('reorder-button');
     const reorderDismiss = document.getElementById('reorder-dismiss');
     const cartLiveStatus = document.getElementById('cart-live-status');
+    const backToTopButton = document.getElementById('back-to-top');
 
     // Annonce vocale pour les lecteurs d'écran lors des modifications du panier
     const announceCartAction = (message) => {
@@ -62,7 +63,16 @@ document.addEventListener('DOMContentLoaded', () => {
             const heroHeight = document.querySelector('.hero')?.offsetHeight || window.innerHeight;
             stickyMobileCta.classList.toggle('is-visible', window.scrollY > heroHeight - 100);
         }
+
+        // Affichage du bouton de retour en haut
+        if (backToTopButton) {
+            backToTopButton.hidden = window.scrollY <= 400;
+        }
     };
+
+    backToTopButton?.addEventListener('click', () => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
 
     // Mise à jour de l'état visuel du stepper de checkout
     const updateStepper = () => {

--- a/index.html
+++ b/index.html
@@ -451,6 +451,13 @@
         </button>
     </div>
 
+    <!-- Bouton de retour en haut de la page -->
+    <button type="button" id="back-to-top" class="back-to-top" aria-label="Retourner en haut de la page" title="Retourner en haut de la page" hidden>
+        <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M18 15l-6-6-6 6"/>
+        </svg>
+    </button>
+
     <div class="cart-overlay" id="cart-overlay"></div>
 
     <aside class="cart-drawer" id="cart-drawer" aria-label="Panier de commande" aria-hidden="true" role="dialog" aria-modal="true">


### PR DESCRIPTION
🎨 Palette Micro-UX Enhancement: Added an accessible, responsive floating "Back to Top" button that appears smoothly as the user scrolls down the page, allowing effortless navigation back to the top of the single-page website on both desktop and mobile devices.

Key features and accessibility improvements:
- Clean SVG icon with explicit `aria-label` and `title` attributes ("Retourner en haut de la page").
- Smooth scrolling behavior via JavaScript `window.scrollTo({ top: 0, behavior: 'smooth' })`.
- Responsive positioning with mobile safe-spacing for the sticky CTA bar.
- Customized focus-visible outline rings for keyboard navigation.
- Full dark mode theme compatibility matching CrazyCook's brand palette.

---
*PR created automatically by Jules for task [7826836682966768045](https://jules.google.com/task/7826836682966768045) started by @sudomarc*