### PR TITLE
🎨 Palette: Retain keyboard focus on cart drawer quantity controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2026-08-13 - [Real-Time Input Counters in Destructive Form Reset Environments]
 **Learning:** In vanilla JavaScript setups where parent containers are destroyed or reset using innerHTML templates, static event listeners directly bound to target input elements (like a character counter) are permanently lost. To make the counter state robust and prevent functional breakage after a form reset, register the input tracking handler via event delegation on a stable parent element, and perform a manual counter re-initialization right after rendering the fresh template.
 **Action:** Always use parent-level event delegation or lifecycle initialization functions when building interactive counter widgets inside dynamically replaced DOM structures.
+
+## 2026-08-20 - [Focus Preservation in Dynamically Re-rendered Modal Lists]
+**Learning:** In vanilla JS dynamic re-renders (such as updating cart item quantities or deleting items in a drawer), completely overwriting `innerHTML` causes active DOM focus to reset to `document.body`. This breaks keyboard navigation for screen reader and keyboard-only users. Tracking target metadata (`id`, `action`, `itemIndex`) during user interactions and applying a post-render focus restoration loop guarantees seamless keyboard navigation.
+**Action:** Always pass `focusInfo` state objects to dynamic re-render functions to re-focus the corresponding or adjacent interactive element.

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -238,7 +238,7 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     // Rendu dynamique du tiroir panier selon l'étape actuelle
-    const renderCart = () => {
+    const renderCart = (focusInfo = null) => {
         if (!cartBody) return;
 
         // Synchroniser le stepper
@@ -265,6 +265,11 @@ document.addEventListener('DOMContentLoaded', () => {
             if (cartValidateButton) {
                 cartValidateButton.textContent = 'Valider ma commande';
                 cartValidateButton.hidden = true; // Cacher le bouton si vide sans style inline
+            }
+
+            if (focusInfo) {
+                const emptyCta = document.getElementById('empty-cart-cta');
+                (emptyCta || drawerClose)?.focus();
             }
             return;
         }
@@ -301,6 +306,21 @@ document.addEventListener('DOMContentLoaded', () => {
             `;
             if (cartTotalPrice) cartTotalPrice.textContent = formatPrice(getSubtotal());
             if (cartValidateButton) cartValidateButton.textContent = 'Valider ma commande';
+
+            if (focusInfo) {
+                let targetEl = null;
+                if (focusInfo.action === 'change') {
+                    targetEl = cartBody.querySelector(`button[data-name="${focusInfo.name}"][data-change="${focusInfo.type}"]`);
+                }
+                if (!targetEl) {
+                    targetEl = cartBody.querySelector(`.cart-remove[data-remove="${focusInfo.name}"]`) ||
+                               cartBody.querySelector('.cart-remove') ||
+                               cartBody.querySelector('.cart-stepper button');
+                }
+                if (targetEl) {
+                    targetEl.focus();
+                }
+            }
             return;
         }
 
@@ -556,14 +576,14 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
             announceCartAction(`${name} retiré du panier.`);
         }
-        renderCart();
+        renderCart({ action: 'change', name, type: delta > 0 ? '+' : '-' });
     };
 
     // Supprimer un plat du panier
     const removeItem = (name) => {
         cart = cart.filter((item) => item.name !== name);
         announceCartAction(`${name} retiré du panier.`);
-        renderCart();
+        renderCart({ action: 'remove', name });
     };
 
     // Redirection WhatsApp de la commande formulée proprement

--- a/tests/visual.spec.js
+++ b/tests/visual.spec.js
@@ -128,3 +128,32 @@ test('end-to-end order placement flow', async ({ page }) => {
 
   console.log('E2E Order flow test completed successfully!');
 });
+
+test('cart drawer stepper retains focus when updating item quantities', async ({ page }) => {
+  await page.goto('/');
+
+  // Add item to cart
+  const addToCartBtn = page.locator('.add-to-cart').first();
+  await addToCartBtn.click();
+
+  // Open cart drawer
+  const cartToggle = page.locator('#header-cart-toggle');
+  await cartToggle.click();
+
+  // Locate the plus (+) button
+  const plusBtn = page.locator('.cart-stepper button[data-change="+"]').first();
+  await expect(plusBtn).toBeVisible();
+
+  // Click plus button
+  await plusBtn.click();
+
+  // Verify focus remains on plus button after re-render
+  await expect(plusBtn).toBeFocused();
+
+  // Locate minus (-) button and click
+  const minusBtn = page.locator('.cart-stepper button[data-change="-"]').first();
+  await minusBtn.click();
+
+  // Verify focus remains on minus button
+  await expect(minusBtn).toBeFocused();
+});


### PR DESCRIPTION
🎨 Palette: Retain keyboard focus on cart drawer quantity controls

💡 What: Preserved keyboard focus on quantity increment (+), decrement (-), and removal controls inside the cart drawer when re-rendering cart DOM.
🎯 Why: Previously, clicking `+` or `-` re-rendered the cart body, destroying the active element and resetting focus to `document.body`. This broke tab navigation for keyboard and screen reader users.
♿ Accessibility: Ensures full keyboard accessibility and seamless screen reader navigation within the cart drawer overlay.

---
*PR created automatically by Jules for task [14065966951475436634](https://jules.google.com/task/14065966951475436634) started by @sudomarc*