### PR TITLE
🎨 Palette: Auto-focus logical elements on checkout step transitions

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -357,6 +357,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 cartValidateButton.textContent = 'Choisir le paiement';
                 cartValidateButton.hidden = false;
             }
+            document.getElementById('delivery-name')?.focus();
             return;
         }
 
@@ -388,6 +389,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (cartValidateButton) {
                 cartValidateButton.hidden = true;
             }
+            cartBody.querySelector('.payment-option')?.focus();
             return;
         }
 
@@ -411,6 +413,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 cartValidateButton.textContent = 'Confirmer le paiement';
                 cartValidateButton.hidden = false;
             }
+            document.getElementById('om-phone')?.focus();
             return;
         }
 
@@ -457,6 +460,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (cartValidateButton) {
                 cartValidateButton.hidden = true; // Cacher le bouton principal car on a le bouton 'restart-order'
             }
+            document.getElementById('restart-order')?.focus();
         }
     };
 

--- a/tests/visual.spec.js
+++ b/tests/visual.spec.js
@@ -157,3 +157,28 @@ test('cart drawer stepper retains focus when updating item quantities', async ({
   // Verify focus remains on minus button
   await expect(minusBtn).toBeFocused();
 });
+
+test('cart drawer step transitions automatically focus logical first elements', async ({ page }) => {
+  await page.goto('/');
+
+  // Add item to cart and open drawer
+  await page.locator('.add-to-cart').first().click();
+  await page.locator('#header-cart-toggle').click();
+
+  // Validate to step 2 (Delivery)
+  await page.locator('#cart-validate').click();
+
+  // Focus should shift to #delivery-name
+  const nameInput = page.locator('#delivery-name');
+  await expect(nameInput).toBeFocused();
+
+  // Fill required delivery fields and validate to step 3 (Payment)
+  await nameInput.fill('Mamadou Diallo');
+  await page.locator('#delivery-phone').fill('628069479');
+  await page.locator('#delivery-address').fill('Kaloum');
+  await page.locator('#cart-validate').click();
+
+  // Focus should shift to first payment option
+  const firstPaymentOption = page.locator('.payment-option').first();
+  await expect(firstPaymentOption).toBeFocused();
+});


### PR DESCRIPTION
Implemented step-transition focus management in the multi-step checkout drawer modal (`assets/js/script.js`). Focus is automatically transferred to the logical primary element (#delivery-name, .payment-option, #om-phone, #restart-order) as the user advances through checkout steps, ensuring screen readers and keyboard users maintain focus context. Included an automated Playwright test case to verify focus behavior.

---
*PR created automatically by Jules for task [15228352831487786727](https://jules.google.com/task/15228352831487786727) started by @sudomarc*