### PR TITLE
🎨 Palette: Dynamic Cart ARIA Labels & 'C' Keyboard Shortcut

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -38,6 +38,31 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     };
 
+    // Mise à jour dynamique des attributs d'accessibilité (aria-label & title) des boutons de panier
+    const updateCartToggleLabels = () => {
+        const itemCount = cart.reduce((total, item) => total + item.quantity, 0);
+        const isOpen = cartDrawer?.classList.contains('is-open');
+
+        let label = '';
+        let title = '';
+
+        if (isOpen) {
+            label = 'Fermer le panier';
+            title = 'Fermer le panier (Échap)';
+        } else {
+            const countText = itemCount === 0 ? 'vide' : `${itemCount} article${itemCount > 1 ? 's' : ''}`;
+            label = `Ouvrir le panier (${countText}) — Touche C`;
+            title = `Ouvrir le panier (${countText}) [C]`;
+        }
+
+        [cartToggle, mobileCartToggle].forEach((btn) => {
+            if (btn) {
+                btn.setAttribute('aria-label', label);
+                btn.setAttribute('title', title);
+            }
+        });
+    };
+
     // Gestion de l'état simple (Panier & Étape de commande)
     let cart = [];
     let currentStep = 'cart'; // 'cart' | 'delivery' | 'payment' | 'processing' | 'confirmation'
@@ -241,8 +266,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const renderCart = (focusInfo = null) => {
         if (!cartBody) return;
 
-        // Synchroniser le stepper
+        // Synchroniser le stepper et les labels des boutons du panier
         updateStepper();
+        updateCartToggleLabels();
 
         // Mise à jour du badge dans le header
         const itemCount = cart.reduce((total, item) => total + item.quantity, 0);
@@ -529,6 +555,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // Ajouter la classe de blocage du défilement
         document.body.classList.add('cart-open');
+        updateCartToggleLabels();
 
         // Mettre le focus sur le bouton de fermeture pour une navigation au clavier fluide
         setTimeout(() => {
@@ -549,6 +576,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // Retirer la classe de blocage du défilement
         document.body.classList.remove('cart-open');
+        updateCartToggleLabels();
 
         // Restituer le focus à l'élément précédemment actif
         if (previouslyFocusedElement && typeof previouslyFocusedElement.focus === 'function') {
@@ -825,8 +853,22 @@ Merci et à très bientôt chez CrazyCook ! ✨`;
     cartOverlay?.addEventListener('click', closeCart);
 
     // Gérer la fermeture du panier avec la touche Échap / Escape & focus trap pour l'accessibilité au clavier
+    // Ainsi que l'ouverture rapide du panier via la touche 'C'
     document.addEventListener('keydown', (e) => {
         const isOpen = cartDrawer?.classList.contains('is-open');
+
+        if (!isOpen && (e.key === 'c' || e.key === 'C')) {
+            const activeElement = document.activeElement;
+            const tagName = activeElement?.tagName.toLowerCase();
+            const isInput = tagName === 'input' || tagName === 'textarea' || tagName === 'select' || activeElement?.isContentEditable;
+
+            if (!isInput) {
+                e.preventDefault();
+                openCart();
+                return;
+            }
+        }
+
         if (!isOpen) return;
 
         if (e.key === 'Escape' || e.key === 'Esc') {

--- a/tests/visual.spec.js
+++ b/tests/visual.spec.js
@@ -182,3 +182,36 @@ test('cart drawer step transitions automatically focus logical first elements', 
   const firstPaymentOption = page.locator('.payment-option').first();
   await expect(firstPaymentOption).toBeFocused();
 });
+
+test('cart drawer toggle labels sync dynamically and key C opens cart drawer', async ({ page }) => {
+  await page.goto('/');
+
+  const headerCartToggle = page.locator('#header-cart-toggle');
+
+  // Verify initial empty state aria-label and title
+  await expect(headerCartToggle).toHaveAttribute('aria-label', 'Ouvrir le panier (vide) — Touche C');
+  await expect(headerCartToggle).toHaveAttribute('title', 'Ouvrir le panier (vide) [C]');
+
+  // Add item to cart
+  await page.locator('.add-to-cart').first().click();
+
+  // Verify updated aria-label and title with item count
+  await expect(headerCartToggle).toHaveAttribute('aria-label', 'Ouvrir le panier (1 article) — Touche C');
+  await expect(headerCartToggle).toHaveAttribute('title', 'Ouvrir le panier (1 article) [C]');
+
+  // Press key 'c' to open cart drawer
+  await page.keyboard.press('c');
+
+  // Cart drawer should be visible with is-open class
+  const cartDrawer = page.locator('#cart-drawer');
+  await expect(cartDrawer).toHaveClass(/is-open/);
+
+  // Label should change to close cart
+  await expect(headerCartToggle).toHaveAttribute('aria-label', 'Fermer le panier');
+  await expect(headerCartToggle).toHaveAttribute('title', 'Fermer le panier (Échap)');
+
+  // Press Escape to close
+  await page.keyboard.press('Escape');
+  await expect(cartDrawer).not.toHaveClass(/is-open/);
+  await expect(headerCartToggle).toHaveAttribute('aria-label', 'Ouvrir le panier (1 article) — Touche C');
+});


### PR DESCRIPTION
💡 What: Implemented updateCartToggleLabels() to dynamically sync aria-label and title attributes on desktop and mobile cart buttons (#header-cart-toggle and #mobile-cart-toggle), and added a global keydown event listener for key 'c'/'C' to open the cart drawer when focus is outside form inputs.

🎯 Why: Enhances screen reader accessibility, provides clear desktop hover tooltips showing item counts, and delights power users with a quick keyboard shortcut.

♿ Accessibility: Screen reader users get real-time context about cart drawer state and item count directly on the toggle controls.

---
*PR created automatically by Jules for task [3735131488104365483](https://jules.google.com/task/3735131488104365483) started by @sudomarc*