### PR TITLE
🎨 Palette: Add keyboard shortcut 'T' for theme toggle with accessible screen reader announcements

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -180,8 +180,8 @@ document.addEventListener('DOMContentLoaded', () => {
         if (theme === 'dark') {
             document.documentElement.setAttribute('data-theme', 'dark');
             themeToggle?.setAttribute('aria-pressed', 'true');
-            themeToggle?.setAttribute('aria-label', 'Basculer le thème clair');
-            themeToggle?.setAttribute('title', 'Basculer le thème clair');
+            themeToggle?.setAttribute('aria-label', 'Basculer le thème clair — Touche T');
+            themeToggle?.setAttribute('title', 'Basculer le thème clair [T]');
             if (themeIcon) {
                 themeIcon.setAttribute('d', 'M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z');
                 themeIcon.setAttribute('fill', 'currentColor');
@@ -189,8 +189,8 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
             document.documentElement.removeAttribute('data-theme');
             themeToggle?.setAttribute('aria-pressed', 'false');
-            themeToggle?.setAttribute('aria-label', 'Basculer le thème sombre');
-            themeToggle?.setAttribute('title', 'Basculer le thème sombre');
+            themeToggle?.setAttribute('aria-label', 'Basculer le thème sombre — Touche T');
+            themeToggle?.setAttribute('title', 'Basculer le thème sombre [T]');
             if (themeIcon) {
                 themeIcon.setAttribute('d', 'M12 3v2M12 19v2M4.2 4.2l1.4 1.4M18.4 18.4l1.4 1.4M1 12h2M21 12h2M4.2 19.8l1.4-1.4M18.4 5.6l1.4-1.4M12 6a6 6 0 100 12 6 6 0 000-12z');
                 themeIcon.setAttribute('fill', 'none');
@@ -218,7 +218,9 @@ document.addEventListener('DOMContentLoaded', () => {
             themeToggle.classList.remove('theme-toggle-rotated');
         }, 450);
 
-        applyTheme(isDark ? 'light' : 'dark');
+        const newTheme = isDark ? 'light' : 'dark';
+        applyTheme(newTheme);
+        announceCartAction(newTheme === 'dark' ? 'Thème sombre activé.' : 'Thème clair activé.');
     });
 
     /* ---------- Image skeleton helper (appelé depuis l'attribut onload/onerror des images) ---------- */
@@ -541,6 +543,8 @@ document.addEventListener('DOMContentLoaded', () => {
     // Affiche la bannière si on a une commande précédente
     showReorderIfNeeded();
 
+    let openCartTimeout = null;
+
     // Ouvrir le tiroir panier
     const openCart = () => {
         if (!cartDrawer) return;
@@ -558,8 +562,9 @@ document.addEventListener('DOMContentLoaded', () => {
         updateCartToggleLabels();
 
         // Mettre le focus sur le bouton de fermeture pour une navigation au clavier fluide
-        setTimeout(() => {
-            if (drawerClose) {
+        if (openCartTimeout) clearTimeout(openCartTimeout);
+        openCartTimeout = setTimeout(() => {
+            if (drawerClose && currentStep === 'cart') {
                 drawerClose.focus();
             }
         }, 50);
@@ -853,9 +858,21 @@ Merci et à très bientôt chez CrazyCook ! ✨`;
     cartOverlay?.addEventListener('click', closeCart);
 
     // Gérer la fermeture du panier avec la touche Échap / Escape & focus trap pour l'accessibilité au clavier
-    // Ainsi que l'ouverture rapide du panier via la touche 'C'
+    // Ainsi que l'ouverture rapide du panier via la touche 'C' et le basculement du thème via la touche 'T'
     document.addEventListener('keydown', (e) => {
         const isOpen = cartDrawer?.classList.contains('is-open');
+
+        if (!isOpen && (e.key === 't' || e.key === 'T')) {
+            const activeElement = document.activeElement;
+            const tagName = activeElement?.tagName.toLowerCase();
+            const isInput = tagName === 'input' || tagName === 'textarea' || tagName === 'select' || activeElement?.isContentEditable;
+
+            if (!isInput) {
+                e.preventDefault();
+                themeToggle?.click();
+                return;
+            }
+        }
 
         if (!isOpen && (e.key === 'c' || e.key === 'C')) {
             const activeElement = document.activeElement;

--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
                     <li><a href="#contact">Contact</a></li>
                     <li>
                         <!-- Toggle thème sombre/clair -->
-                        <button id="theme-toggle" class="theme-toggle" aria-pressed="false" aria-label="Basculer le thème sombre" title="Basculer le thème sombre">
+                        <button id="theme-toggle" class="theme-toggle" aria-pressed="false" aria-label="Basculer le thème sombre — Touche T" title="Basculer le thème sombre [T]">
                             <!-- Sun / Moon inline SVG — simple, pas de librairie -->
                             <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
                                 <path id="theme-icon" d="M12 3v2M12 19v2M4.2 4.2l1.4 1.4M18.4 18.4l1.4 1.4M1 12h2M21 12h2M4.2 19.8l1.4-1.4M18.4 5.6l1.4-1.4M12 6a6 6 0 100 12 6 6 0 000-12z" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" fill="none"></path>

--- a/tests/visual.spec.js
+++ b/tests/visual.spec.js
@@ -215,3 +215,29 @@ test('cart drawer toggle labels sync dynamically and key C opens cart drawer', a
   await expect(cartDrawer).not.toHaveClass(/is-open/);
   await expect(headerCartToggle).toHaveAttribute('aria-label', 'Ouvrir le panier (1 article) — Touche C');
 });
+
+test('key T toggles theme state and updates theme toggle ARIA labels', async ({ page }) => {
+  await page.goto('/');
+
+  const themeToggle = page.locator('#theme-toggle');
+
+  // Verify initial attributes for theme toggle button
+  await expect(themeToggle).toHaveAttribute('aria-label', 'Basculer le thème sombre — Touche T');
+  await expect(themeToggle).toHaveAttribute('title', 'Basculer le thème sombre [T]');
+
+  // Press key 't' to switch to dark mode
+  await page.keyboard.press('t');
+
+  // html element should have data-theme="dark"
+  const html = page.locator('html');
+  await expect(html).toHaveAttribute('data-theme', 'dark');
+
+  // Theme toggle button should now offer switching to light theme
+  await expect(themeToggle).toHaveAttribute('aria-label', 'Basculer le thème clair — Touche T');
+  await expect(themeToggle).toHaveAttribute('title', 'Basculer le thème clair [T]');
+
+  // Press key 't' again to switch back to light mode
+  await page.keyboard.press('t');
+  await expect(html).not.toHaveAttribute('data-theme', 'dark');
+  await expect(themeToggle).toHaveAttribute('aria-label', 'Basculer le thème sombre — Touche T');
+});


### PR DESCRIPTION
Added keyboard shortcut 'T' for toggling the light/dark theme along with dynamic ARIA tooltips and live region accessibility announcements. Fixed drawer focus race conditions and verified with Playwright tests.

---
*PR created automatically by Jules for task [11884968648678596193](https://jules.google.com/task/11884968648678596193) started by @sudomarc*