### PR TITLE
🎨 Palette: Asynchronous Focus Shift in Cart Drawer Step Transitions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@
 ## 2026-08-20 - [Focus Preservation in Dynamically Re-rendered Modal Lists]
 **Learning:** In vanilla JS dynamic re-renders (such as updating cart item quantities or deleting items in a drawer), completely overwriting `innerHTML` causes active DOM focus to reset to `document.body`. This breaks keyboard navigation for screen reader and keyboard-only users. Tracking target metadata (`id`, `action`, `itemIndex`) during user interactions and applying a post-render focus restoration loop guarantees seamless keyboard navigation.
 **Action:** Always pass `focusInfo` state objects to dynamic re-render functions to re-focus the corresponding or adjacent interactive element.
+
+## 2026-08-21 - [Asynchronous Focus Shift in Multi-Step Modal Form Transitions]
+**Learning:** In vanilla JavaScript, calling `.focus()` synchronously inside a button click event listener during dynamic DOM transitions causes the browser's native click handling lifecycle to reset focus back to `document.body` or the triggering element. Wrapping focus calls in `setTimeout(..., 0)` defers focus shifting until after event loop settlement, ensuring reliable focus transfer to the logical first form input in multi-step modal dialogs.
+**Action:** Always wrap `.focus()` calls in `setTimeout(..., 0)` when transitioning between step views inside click event handlers.

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -295,7 +295,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
             if (focusInfo) {
                 const emptyCta = document.getElementById('empty-cart-cta');
-                (emptyCta || drawerClose)?.focus();
+                setTimeout(() => (emptyCta || drawerClose)?.focus(), 0);
             }
             return;
         }
@@ -383,7 +383,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 cartValidateButton.textContent = 'Choisir le paiement';
                 cartValidateButton.hidden = false;
             }
-            document.getElementById('delivery-name')?.focus();
+            setTimeout(() => document.getElementById('delivery-name')?.focus(), 0);
             return;
         }
 
@@ -415,7 +415,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (cartValidateButton) {
                 cartValidateButton.hidden = true;
             }
-            cartBody.querySelector('.payment-option')?.focus();
+            setTimeout(() => cartBody.querySelector('.payment-option')?.focus(), 0);
             return;
         }
 
@@ -439,7 +439,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 cartValidateButton.textContent = 'Confirmer le paiement';
                 cartValidateButton.hidden = false;
             }
-            document.getElementById('om-phone')?.focus();
+            setTimeout(() => document.getElementById('om-phone')?.focus(), 0);
             return;
         }
 
@@ -486,7 +486,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (cartValidateButton) {
                 cartValidateButton.hidden = true; // Cacher le bouton principal car on a le bouton 'restart-order'
             }
-            document.getElementById('restart-order')?.focus();
+            setTimeout(() => document.getElementById('restart-order')?.focus(), 0);
         }
     };
 


### PR DESCRIPTION
💡 What: Defer focus management calls inside renderCart() (#delivery-name, .payment-option, #om-phone, #restart-order, #empty-cart-cta) asynchronously using setTimeout(..., 0) during cart step transitions.

🎯 Why: Calling .focus() synchronously inside button click listeners causes browser click lifecycle defaults to override element focus after DOM re-renders. Deferring focus shifting guarantees focus is moved to the primary form field/control on step transitions.

♿ Accessibility: Screen reader and keyboard navigation users are now seamlessly placed in the active step's initial input rather than having focus dropped or reset.

---
*PR created automatically by Jules for task [2191094917863822588](https://jules.google.com/task/2191094917863822588) started by @sudomarc*