### PR TITLE
🎨 Palette: Add dynamic in-cart quantity badges & screen reader updates on menu dish cards

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-08-21 - [Asynchronous Focus Shift in Multi-Step Modal Form Transitions]
 **Learning:** In vanilla JavaScript, calling `.focus()` synchronously inside a button click event listener during dynamic DOM transitions causes the browser's native click handling lifecycle to reset focus back to `document.body` or the triggering element. Wrapping focus calls in `setTimeout(..., 0)` defers focus shifting until after event loop settlement, ensuring reliable focus transfer to the logical first form input in multi-step modal dialogs.
 **Action:** Always wrap `.focus()` calls in `setTimeout(..., 0)` when transitioning between step views inside click event handlers.
+
+## 2026-08-22 - [In-Cart Quantity Badges and Dynamic ARIA Syncing on Catalog Item Cards]
+**Learning:** When users browse a menu or catalog, lack of immediate item quantity feedback on item cards causes cognitive load and forces repetitive cart drawer toggles. Dynamically injecting an in-cart quantity pill badge (`.order-pill`) next to action buttons and synchronizing screen-reader `aria-label` attributes (`Ajouter X au panier (N dans le panier)`) whenever cart state updates provides seamless visual and auditory context.
+**Action:** Connect catalog card badge rendering directly to the central cart render loop so all cart mutations (adding, updating, reordering, clearing) instantly reflect item counts on catalog cards.

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -63,6 +63,38 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     };
 
+    // Mise à jour dynamique des badges et attributs ARIA sur les cartes de plats du menu
+    const updateDishBadges = () => {
+        document.querySelectorAll('.add-to-cart').forEach((button) => {
+            const name = button.dataset.name;
+            if (!name) return;
+            const item = cart.find((i) => i.name === name);
+            const count = item ? item.quantity : 0;
+            const card = button.closest('.dish-card');
+            if (!card) return;
+
+            let badge = card.querySelector('.dish-cart-count');
+            if (count > 0) {
+                if (!badge) {
+                    badge = document.createElement('span');
+                    badge.className = 'order-pill dish-cart-count';
+                    badge.style.marginRight = '0.5rem';
+                    badge.style.marginTop = '0';
+                    const actions = card.querySelector('.dish-actions') || card;
+                    actions.insertBefore(badge, button);
+                }
+                badge.textContent = `${count} dans le panier`;
+                badge.hidden = false;
+                button.setAttribute('aria-label', `Ajouter ${name} au panier (${count} dans le panier)`);
+            } else {
+                if (badge) {
+                    badge.hidden = true;
+                }
+                button.setAttribute('aria-label', `Ajouter ${name} au panier`);
+            }
+        });
+    };
+
     // Gestion de l'état simple (Panier & Étape de commande)
     let cart = [];
     let currentStep = 'cart'; // 'cart' | 'delivery' | 'payment' | 'processing' | 'confirmation'
@@ -269,6 +301,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // Synchroniser le stepper et les labels des boutons du panier
         updateStepper();
         updateCartToggleLabels();
+        updateDishBadges();
 
         // Mise à jour du badge dans le header
         const itemCount = cart.reduce((total, item) => total + item.quantity, 0);

--- a/tests/visual.spec.js
+++ b/tests/visual.spec.js
@@ -215,3 +215,34 @@ test('cart drawer toggle labels sync dynamically and key C opens cart drawer', a
   await expect(cartDrawer).not.toHaveClass(/is-open/);
   await expect(headerCartToggle).toHaveAttribute('aria-label', 'Ouvrir le panier (1 article) — Touche C');
 });
+
+test('dish cards update in-cart badge and aria-label dynamically', async ({ page }) => {
+  await page.goto('/');
+
+  const firstDishCard = page.locator('.dish-card').first();
+  const firstAddBtn = firstDishCard.locator('.add-to-cart');
+  const badge = firstDishCard.locator('.dish-cart-count');
+
+  // Verify badge is initially non-existent or hidden
+  await expect(badge).toBeHidden();
+
+  // Click add to cart
+  await firstAddBtn.click();
+
+  // Verify badge becomes visible with '1 dans le panier'
+  await expect(badge).toBeVisible();
+  await expect(badge).toHaveText('1 dans le panier');
+  await expect(firstAddBtn).toHaveAttribute('aria-label', /1 dans le panier/);
+
+  // Click add to cart a second time
+  await firstAddBtn.click();
+
+  // Verify count updates to '2 dans le panier'
+  await expect(badge).toHaveText('2 dans le panier');
+  await expect(firstAddBtn).toHaveAttribute('aria-label', /2 dans le panier/);
+
+  // Capture screenshot of updated dish card with in-cart badge
+  const dishCardScreenshotPath = '/home/jules/verification/verification_dish_badge.png';
+  await firstDishCard.screenshot({ path: dishCardScreenshotPath });
+  console.log('Dish card badge screenshot saved to:', dishCardScreenshotPath);
+});


### PR DESCRIPTION
Added dynamic updateDishBadges() function in assets/js/script.js to render in-cart quantity badges on menu dish cards and synchronize aria-labels for screen reader accessibility when items are added, modified, or cleared. Added automated Playwright test in tests/visual.spec.js.

---
*PR created automatically by Jules for task [18264818338237186938](https://jules.google.com/task/18264818338237186938) started by @sudomarc*